### PR TITLE
Add WebGL dragon curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # The Dragon Curve
 
 Little project to dynamically show the evolution of the recursive construction of the Dragon Curve Fractal and its variants with a light Javascript implementation with the 2D Canvas API.
+
+## WebGL version
+
+The repository now includes `dragon_webgl.html`, a simple WebGL implementation that draws the Dragon Curve using GPU lines. Open the file in a browser with WebGL support to see the fractal iteratively generated.

--- a/dragon_webgl.html
+++ b/dragon_webgl.html
@@ -1,0 +1,153 @@
+<html>
+<head>
+    <title>Dragon Curve WebGL</title>
+    <style>
+        body { margin:0; }
+        canvas { width:100vw; height:100vh; display:block; }
+    </style>
+</head>
+<body>
+<canvas id="glcanvas"></canvas>
+<script>
+"use strict";
+
+var gl;
+var shaderProgram;
+var vertexBuffer;
+
+var points = [ {x:200, y:500}, {x:800, y:500} ];
+
+function middlePoint(a, b, up){
+    var dx = a.x - b.x;
+    var dy = a.y - b.y;
+    var c = {x:(a.x + b.x) / 2, y:(a.y + b.y) / 2};
+    var m = {x:-dy / 2, y:dx / 2};
+    if (!up){
+        m.x *= -1;
+        m.y *= -1;
+    }
+    return {x: m.x + c.x, y: m.y + c.y};
+}
+
+function iterateDragon(){
+    var points2 = [];
+    var up = true;
+    for (var i = 0; i < points.length-1; i++) {
+        var a = points[i];
+        var b = points[i+1];
+        var m = middlePoint(a,b, up);
+        up = !up;
+        points2.push(a);
+        points2.push(m);
+    }
+    points2.push(points[points.length-1]);
+    points = points2;
+}
+
+function initGL(canvas) {
+    gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+    if (!gl) {
+        alert("Could not initialise WebGL");
+    }
+}
+
+function getShader(gl, type, source) {
+    var shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        console.log(gl.getShaderInfoLog(shader));
+        return null;
+    }
+    return shader;
+}
+
+function initShaders() {
+    var vsSource = `
+        attribute vec2 aVertexPosition;
+        void main(void) {
+            gl_Position = vec4(aVertexPosition, 0.0, 1.0);
+        }
+    `;
+    var fsSource = `
+        precision mediump float;
+        uniform vec4 uColor;
+        void main(void) {
+            gl_FragColor = uColor;
+        }
+    `;
+    var vertexShader = getShader(gl, gl.VERTEX_SHADER, vsSource);
+    var fragmentShader = getShader(gl, gl.FRAGMENT_SHADER, fsSource);
+
+    shaderProgram = gl.createProgram();
+    gl.attachShader(shaderProgram, vertexShader);
+    gl.attachShader(shaderProgram, fragmentShader);
+    gl.linkProgram(shaderProgram);
+
+    if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+        alert("Could not initialise shaders");
+    }
+
+    gl.useProgram(shaderProgram);
+
+    shaderProgram.vertexPositionAttribute = gl.getAttribLocation(shaderProgram, "aVertexPosition");
+    gl.enableVertexAttribArray(shaderProgram.vertexPositionAttribute);
+    shaderProgram.colorUniform = gl.getUniformLocation(shaderProgram, "uColor");
+}
+
+function initBuffers() {
+    vertexBuffer = gl.createBuffer();
+}
+
+function toClipSpace(p, width, height){
+    return [ (p.x / width) * 2 - 1, 1 - (p.y / height) * 2 ];
+}
+
+function drawScene() {
+    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+    gl.clearColor(0.0, 0.0, 0.0, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    var verts = [];
+    for (var i = 0; i < points.length; i++) {
+        var c = toClipSpace(points[i], gl.canvas.width, gl.canvas.height);
+        verts.push(c[0], c[1]);
+    }
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STATIC_DRAW);
+    gl.vertexAttribPointer(shaderProgram.vertexPositionAttribute, 2, gl.FLOAT, false, 0, 0);
+    gl.uniform4f(shaderProgram.colorUniform, 1.0, 1.0, 1.0, 1.0);
+    gl.drawArrays(gl.LINE_STRIP, 0, verts.length/2);
+}
+
+var iteration = 0;
+var maxIterations = 18;
+function iterateAndDraw() {
+    iterateDragon();
+    drawScene();
+    iteration++;
+    if (iteration === maxIterations) {
+        window.clearInterval(intervalID);
+    }
+}
+
+var intervalID;
+window.onload = function() {
+    var canvas = document.getElementById("glcanvas");
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    points = [ {x:canvas.width*0.25, y:canvas.height*0.65},
+               {x:canvas.width*0.75, y:canvas.height*0.65} ];
+
+    initGL(canvas);
+    initShaders();
+    initBuffers();
+
+    drawScene();
+    intervalID = window.setInterval(iterateAndDraw, 1000);
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a working WebGL version of the Dragon Curve
- document new WebGL file in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840874582e8832aa2e57630763590c0