### PR TITLE
Add Vue curve viewer

### DIFF
--- a/vue-app/README.md
+++ b/vue-app/README.md
@@ -1,0 +1,18 @@
+# Vue Dragon Curve
+
+This folder contains a small Vue application that displays the Dragon Curve. Use the slider at the bottom to set the curve evolution from 0 to 100 and press **Play** to animate it, one percent per second.
+
+## Serving the page with Node on Windows
+
+1. Install [Node.js](https://nodejs.org/) if not already installed.
+2. From a command prompt inside this directory, install the dependencies:
+   ```
+   npm install express
+   ```
+3. Start the server:
+   ```
+   node server.js
+   ```
+4. Open `http://localhost:3000` in your browser.
+
+The `server.js` script uses Express to serve the static files located in this folder.

--- a/vue-app/app.js
+++ b/vue-app/app.js
@@ -1,0 +1,90 @@
+const { createApp } = Vue;
+
+function middlePoint(a, b, up) {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    const c = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+    let m = { x: -dy / 2, y: dx / 2 };
+    if (!up) {
+        m.x *= -1;
+        m.y *= -1;
+    }
+    return { x: c.x + m.x, y: c.y + m.y };
+}
+
+function computeDragon(iterations) {
+    let pts = [{ x: 0.1, y: 0.5 }, { x: 0.9, y: 0.5 }];
+    for (let it = 0; it < iterations; it++) {
+        const newPts = [];
+        let up = true;
+        for (let i = 0; i < pts.length - 1; i++) {
+            const a = pts[i];
+            const b = pts[i + 1];
+            const m = middlePoint(a, b, up);
+            up = !up;
+            newPts.push(a, m);
+        }
+        newPts.push(pts[pts.length - 1]);
+        pts = newPts;
+    }
+    return pts;
+}
+
+createApp({
+    data() {
+        return {
+            progress: 0,
+            playing: false,
+            intervalId: null,
+            points: [],
+            ctx: null,
+        };
+    },
+    mounted() {
+        const canvas = document.getElementById('viewer');
+        this.ctx = canvas.getContext('2d');
+        const resize = () => {
+            canvas.width = this.$el.clientWidth;
+            canvas.height = this.$el.clientHeight - document.getElementById('controls').offsetHeight;
+            this.draw();
+        };
+        window.addEventListener('resize', resize);
+        resize();
+        this.points = computeDragon(15);
+        this.draw();
+    },
+    methods: {
+        draw() {
+            const ctx = this.ctx;
+            if (!ctx) return;
+            const canvas = ctx.canvas;
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            const count = Math.floor(this.points.length * (this.progress / 100));
+            if (count < 2) return;
+            ctx.beginPath();
+            ctx.moveTo(this.points[0].x * canvas.width, this.points[0].y * canvas.height);
+            for (let i = 1; i < count; i++) {
+                const p = this.points[i];
+                ctx.lineTo(p.x * canvas.width, p.y * canvas.height);
+            }
+            ctx.stroke();
+        },
+        togglePlay() {
+            if (this.playing) {
+                clearInterval(this.intervalId);
+                this.playing = false;
+            } else {
+                this.playing = true;
+                this.intervalId = setInterval(() => {
+                    if (this.progress >= 100) {
+                        clearInterval(this.intervalId);
+                        this.playing = false;
+                    } else {
+                        this.progress += 1;
+                        this.draw();
+                    }
+                }, 1000);
+            }
+        }
+    }
+}).mount('#app');

--- a/vue-app/index.html
+++ b/vue-app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dragon Curve Vue</title>
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+    <style>
+        body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
+        #viewer { flex: 1; }
+        #controls { padding: 10px; background: #eee; display: flex; align-items: center; }
+        #slider { flex: 1; margin: 0 10px; }
+    </style>
+</head>
+<body>
+<div id="app">
+    <canvas id="viewer"></canvas>
+    <div id="controls">
+        <button @click="togglePlay">{{ playing ? 'Pause' : 'Play' }}</button>
+        <input id="slider" type="range" min="0" max="100" v-model.number="progress" @input="draw" />
+        <span>{{ Math.floor(progress) }}%</span>
+    </div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/vue-app/server.js
+++ b/vue-app/server.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+const PORT = process.env.PORT || 3000;
+app.use(express.static(__dirname));
+
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement a simple Dragon Curve viewer with Vue
- include slider and play button
- add README describing how to serve the page with Node on Windows
- add small Express server

## Testing
- `node vue-app/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68408931dfcc832a972e6fa05460f8d1