### PR TITLE
Improve GitHub Pages styling

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -58,9 +58,9 @@ createApp({
             const ctx = this.ctx;
             if (!ctx) return;
             const canvas = ctx.canvas;
-            ctx.fillStyle = 'blue';
+            ctx.fillStyle = '#111';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.strokeStyle = 'red';
+            ctx.strokeStyle = '#40c4ff';
             ctx.lineWidth = 2;
             const count = Math.floor(this.points.length * (this.progress / 100));
             if (count < 2) return;

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,16 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dragon Curve Viewer</title>
     <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-    <style>
-        body { margin: 0; }
-        #app { display: flex; flex-direction: column; height: 100vh; }
-        #viewer { flex: 1; width: 100%; background: blue; display: block; }
-        h1 { text-align: center; margin: 10px 0; color: white; }
-        #controls { padding: 10px; background: #eee; display: flex; align-items: center; }
-        #slider { flex: 1; margin: 0 10px; }
-    </style>
+    <link rel="stylesheet" href="style.css" />
 </head>
 <body>
 <div id="app">

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,54 @@
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(120deg, #0f2027, #203a43, #2c5364);
+  color: white;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+#viewer {
+  flex: 1;
+  width: 100%;
+  background: #111;
+  display: block;
+  border: 2px solid #eee;
+}
+
+h1 {
+  text-align: center;
+  margin: 10px 0;
+  font-weight: 300;
+  letter-spacing: 1px;
+}
+
+#controls {
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  backdrop-filter: blur(5px);
+}
+
+button {
+  padding: 5px 15px;
+  background: #2c5364;
+  border: none;
+  color: white;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #203a43;
+}
+
+#slider {
+  flex: 1;
+  margin: 0 10px;
+}


### PR DESCRIPTION
## Summary
- restyle GitHub Pages site with new modern look
- reference new style.css from index
- adjust canvas colors to fit new theme

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/dragonCurve/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6841909ca798832ab5aaf58f37dccb18